### PR TITLE
fix: switch to ubuntu:22.04 base and install libzip5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ FROM ghcr.io/stubbi/katago-server:base AS runtime-base
 
 # Install wget and unzip for downloading KataGo
 RUN apt-get update && apt-get install -y \
-    wget \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+  wget \
+  unzip \
+  libzip5 \
+  && rm -rf /var/lib/apt/lists/*
 
 # Download KataGo and model in parallel, then configure
 # Default: CPU-only version (eigen build for broad compatibility)
@@ -17,21 +18,21 @@ ARG KATAGO_VERSION=v1.14.1
 ARG KATAGO_BUILD=eigen
 
 RUN set -ex && \
-    # Download KataGo binary and model in parallel using background jobs
-    wget -q https://github.com/lightvector/KataGo/releases/download/${KATAGO_VERSION}/katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip & \
-    wget -q -O kata1-b15c192-s1672170752-d466197061.bin.gz https://katagotraining.org/api/networks/kata1-b15c192-s1672170752-d466197061/network_file & \
-    wait && \
-    # Extract and cleanup
-    unzip -q katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip && \
-    chmod +x katago && \
-    rm katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip && \
-    # Create default configs optimized for CPU usage
-    cp config.toml.example config.toml && \
-    cp gtp_config.cfg.example gtp_config.cfg && \
-    sed -i 's/numSearchThreads = 4/numSearchThreads = 2/' gtp_config.cfg && \
-    sed -i 's/maxVisits = 500/maxVisits = 200/' gtp_config.cfg && \
-    # Fix model path in config to match downloaded filename
-    sed -i 's|model_path = ".*"|model_path = "./kata1-b15c192-s1672170752-d466197061.bin.gz"|' config.toml
+  # Download KataGo binary and model in parallel using background jobs
+  wget -q https://github.com/lightvector/KataGo/releases/download/${KATAGO_VERSION}/katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip & \
+  wget -q -O kata1-b15c192-s1672170752-d466197061.bin.gz https://katagotraining.org/api/networks/kata1-b15c192-s1672170752-d466197061/network_file & \
+  wait && \
+  # Extract and cleanup
+  unzip -q katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip && \
+  chmod +x katago && \
+  rm katago-${KATAGO_VERSION}-${KATAGO_BUILD}-linux-x64.zip && \
+  # Create default configs optimized for CPU usage
+  cp config.toml.example config.toml && \
+  cp gtp_config.cfg.example gtp_config.cfg && \
+  sed -i 's/numSearchThreads = 4/numSearchThreads = 2/' gtp_config.cfg && \
+  sed -i 's/maxVisits = 500/maxVisits = 200/' gtp_config.cfg && \
+  # Fix model path in config to match downloaded filename
+  sed -i 's|model_path = ".*"|model_path = "./kata1-b15c192-s1672170752-d466197061.bin.gz"|' config.toml
 
 EXPOSE 2718
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,7 +25,7 @@ COPY src ./src
 RUN touch src/main.rs && cargo build --release
 
 # Base runtime image with just the binary
-FROM debian:bookworm-slim AS runtime-base
+FROM ubuntu:22.04 AS runtime-base
 
 WORKDIR /app
 
@@ -46,4 +46,4 @@ EXPOSE 2718
 ENV RUST_LOG=info
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:2718/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:2718/health || exit 1

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -11,11 +11,12 @@ FROM nvidia/cuda:12.2.0-base-ubuntu22.04
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    wget \
-    unzip \
-    libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
+  ca-certificates \
+  wget \
+  unzip \
+  libgomp1 \
+  libzip5 \
+  && rm -rf /var/lib/apt/lists/*
 
 # Copy binary and configs from base image
 COPY --from=binary /app/katago-server /app/
@@ -27,21 +28,21 @@ ARG KATAGO_VERSION=v1.14.1
 ARG CUDA_VERSION=cuda12.1-cudnn8.9.7
 
 RUN set -ex && \
-    # Download KataGo binary and model in parallel
-    wget -q https://github.com/lightvector/KataGo/releases/download/${KATAGO_VERSION}/katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip & \
-    wget -q -O model.bin.gz https://katagotraining.org/api/networks/kata1-b40c256-s11840935168-d2898845681/network_file & \
-    wait && \
-    # Extract and cleanup
-    unzip -q katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip && \
-    chmod +x katago && \
-    rm katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip && \
-    # Create GPU-optimized configs
-    cp config.toml.example config.toml && \
-    cp gtp_config.cfg.example gtp_config.cfg && \
-    sed -i 's/numSearchThreads = 4/numSearchThreads = 8/' gtp_config.cfg && \
-    sed -i 's/maxVisits = 500/maxVisits = 800/' gtp_config.cfg && \
-    sed -i 's/# numNNServerThreadsPerModel = 1/numNNServerThreadsPerModel = 2/' gtp_config.cfg && \
-    sed -i 's/# nnMaxBatchSize = 16/nnMaxBatchSize = 32/' gtp_config.cfg
+  # Download KataGo binary and model in parallel
+  wget -q https://github.com/lightvector/KataGo/releases/download/${KATAGO_VERSION}/katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip & \
+  wget -q -O model.bin.gz https://katagotraining.org/api/networks/kata1-b40c256-s11840935168-d2898845681/network_file & \
+  wait && \
+  # Extract and cleanup
+  unzip -q katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip && \
+  chmod +x katago && \
+  rm katago-${KATAGO_VERSION}-${CUDA_VERSION}-linux-x64.zip && \
+  # Create GPU-optimized configs
+  cp config.toml.example config.toml && \
+  cp gtp_config.cfg.example gtp_config.cfg && \
+  sed -i 's/numSearchThreads = 4/numSearchThreads = 8/' gtp_config.cfg && \
+  sed -i 's/maxVisits = 500/maxVisits = 800/' gtp_config.cfg && \
+  sed -i 's/# numNNServerThreadsPerModel = 1/numNNServerThreadsPerModel = 2/' gtp_config.cfg && \
+  sed -i 's/# nnMaxBatchSize = 16/nnMaxBatchSize = 32/' gtp_config.cfg
 
 EXPOSE 2718
 


### PR DESCRIPTION
- KataGo binary requires libzip.so.5 which is available in Ubuntu 22.04
- Switched base image from debian:bookworm-slim to ubuntu:22.04
- Added libzip5 to runtime dependencies in Dockerfile and Dockerfile.gpu