### PR TITLE
Fix Helm release workflow to handle existing releases

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -100,10 +100,12 @@ jobs:
 
       - name: Create GitHub Release
         if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: .cr-release-packages/*.tgz
           generate_release_notes: true
+          fail_on_unmatched_files: false
+          make_latest: true
           body: |
             ## Helm Chart Release
 


### PR DESCRIPTION
- Upgrade softprops/action-gh-release to v2
- Add fail_on_unmatched_files: false to prevent failures
- Add make_latest: true to mark as latest release