### PR TITLE
Sync chart version with appVersion (both 0.2.1)

### DIFF
--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.1
 
 # This is the version number of the application being deployed.
 appVersion: "0.2.1"


### PR DESCRIPTION
This ensures the chart version, appVersion, Docker tag, and git tag all match, making releases less confusing.