### PR TITLE
Fix image tag defaulting to appVersion when empty

### DIFF
--- a/charts/katago-server/templates/_helpers.tpl
+++ b/charts/katago-server/templates/_helpers.tpl
@@ -65,7 +65,10 @@ Create the name of the service account to use
 Generate the image name with variant
 */}}
 {{- define "katago-server.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.image.tag -}}
+{{- if not $tag -}}
+{{- $tag = .Chart.AppVersion -}}
+{{- end -}}
 {{- if .Values.image.variant }}
 {{- printf "%s:%s%s" .Values.image.repository $tag .Values.image.variant }}
 {{- else }}


### PR DESCRIPTION
The previous logic using 'default' filter didn't work because empty string "" is a defined value in Go templates, so default never triggered.

Now explicitly checks if tag is empty and falls back to Chart.AppVersion.