### PR TITLE
Release version 0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,10 +136,12 @@ jobs:
         with:
           images: ${{ steps.image.outputs.name }}
           flavor: |
-            suffix=${{ matrix.variant == 'base' && '' || format('-{0}', matrix.variant) }},onlatest=true
+            suffix=${{ matrix.variant == 'cpu' && '' || format('-{0}', matrix.variant) }},onlatest=true
           tags: |
             type=raw,value=${{ needs.detect-version-change.outputs.new_version }}
             type=raw,value=latest
+            type=raw,value=${{ needs.detect-version-change.outputs.new_version }}-cpu,enable=${{ matrix.variant == 'cpu' }}
+            type=raw,value=latest-cpu,enable=${{ matrix.variant == 'cpu' }}
           labels: |
             org.opencontainers.image.title=KataGo Server (${{ matrix.variant }})
             org.opencontainers.image.description=KataGo Server - ${{ matrix.variant }} variant
@@ -256,11 +258,14 @@ jobs:
 
             This release includes the following Docker images:
 
-            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}` (CPU variant - default)
-            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}-minimal` (Minimal variant - BYO KataGo)
-            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}-base` (Base variant - binary only)
+            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}` or `:latest` (CPU variant - **default**)
+            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}-cpu` or `:latest-cpu` (CPU variant - explicit tag)
+            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}-minimal` or `:latest-minimal` (Minimal variant - BYO KataGo)
+            - `ghcr.io/stubbi/katago-server:${{ needs.detect-version-change.outputs.new_version }}-base` or `:latest-base` (Base variant - binary only)
 
             All images are available for `linux/amd64` and `linux/arm64` platforms.
+
+            **Note:** The default image (without suffix) points to the CPU variant. Both `:${{ needs.detect-version-change.outputs.new_version }}` and `:${{ needs.detect-version-change.outputs.new_version }}-cpu` reference the same CPU image.
 
             ## Helm Chart
 

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed.
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 
 keywords:
   - katago

--- a/charts/katago-server/values.yaml
+++ b/charts/katago-server/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  # Image variant: "" (default/cpu), "-minimal", "-base"
+  # Image variant: "" (cpu - default), "-cpu" (explicit), "-minimal" (BYO KataGo), "-base" (binary only)
   variant: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
This release includes:
- Bump chart version from 0.3.0 to 0.5.0
- Bump app version from 0.3.0 to 0.5.0
- Fix Helm chart release workflow to use chart-releaser-action
- Make CPU variant the default Docker image

Docker image tagging changes:
- CPU variant is now tagged as both 0.5.0 AND 0.5.0-cpu (both latest and latest-cpu)
- Base variant now always has -base suffix (0.5.0-base, latest-base)
- Minimal variant keeps -minimal suffix (0.5.0-minimal, latest-minimal)
- The plain tags (0.5.0, latest) now point to the CPU variant

This ensures users get the CPU variant by default (the most commonly used), while still allowing explicit variant selection via suffixes.