### PR TITLE
Disable pushing attestations to GHCR to reduce registry clutter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
         with:
           subject-name: ${{ steps.image.outputs.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false
 
   # ===========================================================================
   # Release Helm Chart


### PR DESCRIPTION
Attestations are still generated for security/compliance but are not pushed to the container registry, preventing SHA256 artifact noise in the GHCR package versions list.