### PR TITLE
fix(chart): add KATAGO_MODEL_PATH env for custom models and increase …

### DIFF
--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0"

--- a/charts/katago-server/templates/deployment.yaml
+++ b/charts/katago-server/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
           value: {{ .Values.config.logLevel | quote }}
         - name: KATAGO_MOVE_TIMEOUT_SECS
           value: {{ .Values.config.katago.moveTimeoutSecs | quote }}
+        {{- if .Values.config.customModel.enabled }}
+        - name: KATAGO_MODEL_PATH
+          value: /app/models/{{ .Values.config.customModel.filename }}
+        {{- end }}
         {{- if .Values.config.customConfig }}
         - name: KATAGO_SERVER__CONFIG_PATH
           value: /config/config.toml

--- a/charts/katago-server/values.yaml
+++ b/charts/katago-server/values.yaml
@@ -108,10 +108,10 @@ startupProbe:
   httpGet:
     path: /api/v1/health
     port: http
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 12
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
…startup probe timeout

- Set KATAGO_MODEL_PATH environment variable when customModel is enabled so the server uses the downloaded model instead of the built-in one
- Increase startup probe timeout from 60s to 330s to allow more time for model download and KataGo initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)