### PR TITLE
fix: env vars override file config for custom model support

### DIFF
--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 keywords:
   - katago

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,28 +52,37 @@ impl Config {
         Ok(config)
     }
 
-    pub fn from_env() -> anyhow::Result<Self> {
-        let mut config = Config::default();
-
+    /// Apply environment variable overrides to the config.
+    /// Environment variables take precedence over file/default values.
+    pub fn apply_env_overrides(&mut self) {
         if let Ok(host) = std::env::var("KATAGO_SERVER_HOST") {
-            config.server.host = host;
+            self.server.host = host;
         }
         if let Ok(port) = std::env::var("KATAGO_SERVER_PORT") {
-            config.server.port = port.parse()?;
+            if let Ok(p) = port.parse() {
+                self.server.port = p;
+            }
         }
         if let Ok(path) = std::env::var("KATAGO_KATAGO_PATH") {
-            config.katago.katago_path = path;
+            self.katago.katago_path = path;
         }
         if let Ok(path) = std::env::var("KATAGO_MODEL_PATH") {
-            config.katago.model_path = path;
+            self.katago.model_path = path;
         }
         if let Ok(path) = std::env::var("KATAGO_CONFIG_PATH") {
-            config.katago.config_path = path;
+            self.katago.config_path = path;
         }
         if let Ok(timeout) = std::env::var("KATAGO_MOVE_TIMEOUT_SECS") {
-            config.katago.move_timeout_secs = timeout.parse()?;
+            if let Ok(t) = timeout.parse() {
+                self.katago.move_timeout_secs = t;
+            }
         }
+    }
 
+    #[allow(dead_code)] // Used in tests and for standalone env-only config loading
+    pub fn from_env() -> anyhow::Result<Self> {
+        let mut config = Config::default();
+        config.apply_env_overrides();
         Ok(config)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,13 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // Load configuration
-    let config = Config::from_file("config.toml")
-        .or_else(|_| Config::from_env())
-        .unwrap_or_else(|_| {
-            info!("Using default configuration");
-            Config::default()
-        });
+    // Load configuration: file -> defaults -> env overrides
+    // Environment variables always take precedence
+    let mut config = Config::from_file("config.toml").unwrap_or_else(|_| {
+        info!("No config.toml found, using defaults");
+        Config::default()
+    });
+    config.apply_env_overrides();
 
     info!("Starting KataGo server with config: {:?}", config);
 


### PR DESCRIPTION
## Summary
- Environment variables now always take precedence over config.toml values
- Fixes issue where custom models configured via Helm charts were ignored because Docker image has baked-in config.toml
- Adds `apply_env_overrides()` method to Config that is always called after loading config file

## Problem
When deploying with custom models via Helm charts, the `KATAGO_MODEL_PATH` environment variable was being ignored. The root cause was that the Docker image has a `config.toml` baked in with hardcoded paths, and the previous config loading logic used `or_else` which only read env vars when no file was present.

## Solution
Changed config loading to always apply environment variable overrides after loading from file, so that:
1. Load config from file (or use defaults if no file)
2. Always apply env var overrides on top

## Test plan
- [x] All 24 unit tests pass (`cargo test`)
- [ ] Deploy to cluster and verify custom model is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)