### PR TITLE
fix: update image repository to goban-app organization

### DIFF
--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed.
 appVersion: "1.1.0"

--- a/charts/katago-server/values.yaml
+++ b/charts/katago-server/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/stubbi/katago-server
+  repository: ghcr.io/goban-app/katago-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
## Summary
- Update default image repository from `ghcr.io/stubbi/katago-server` to `ghcr.io/goban-app/katago-server`
- Bump chart version to 1.2.1

The repository was moved to the goban-app organization but the chart still referenced the old path.

## Test plan
- [ ] Verify ArgoCD deployment pulls from the correct image registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)