### PR TITLE
chore: bump app version to 1.2.0 for env override fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katago-server"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed.
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 
 keywords:
   - katago


### PR DESCRIPTION
## Summary
- Bumps Cargo.toml version from 0.2.1 to 0.2.2
- Bumps chart version from 1.2.1 to 1.2.2
- Bumps appVersion from 1.1.0 to 1.2.0

The env override fix was merged in chart 1.2.1 but the Docker image was not rebuilt because appVersion didn't change. This triggers a new Docker image build with the fix that allows `KATAGO_MODEL_PATH` environment variable to override the config.toml setting.

## Test plan
- [ ] CI passes
- [ ] New Docker image is published as `ghcr.io/goban-app/katago-server:1.2.0`
- [ ] Deploy to cluster and verify custom human-style model is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)