### PR TITLE
feat: upgrade KataGo to v1.15.0 for human-style model support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Clone specific version
-RUN git clone --depth 1 -b v1.14.1 https://github.com/lightvector/KataGo.git
+# Clone specific version (v1.15.0 required for human-style model support)
+RUN git clone --depth 1 -b v1.15.0 https://github.com/lightvector/KataGo.git
 
 WORKDIR /build/KataGo/cpp
 
@@ -131,8 +131,8 @@ RUN wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/lin
 
 WORKDIR /build
 
-# Clone specific version
-RUN git clone --depth 1 -b v1.14.1 https://github.com/lightvector/KataGo.git
+# Clone specific version (v1.15.0 required for human-style model support)
+RUN git clone --depth 1 -b v1.15.0 https://github.com/lightvector/KataGo.git
 
 WORKDIR /build/KataGo/cpp
 

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,10 +5,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.2
+version: 1.3.0
 
 # This is the version number of the application being deployed.
-appVersion: "1.2.0"
+# KataGo v1.15.0 required for human-style model support
+appVersion: "1.3.0"
 
 keywords:
   - katago


### PR DESCRIPTION
## Summary
- Upgrade KataGo from v1.14.1 to v1.15.0 in the Dockerfile
- The human-style model (`b18c384nbt-humanv0.bin.gz`) from KataGo v1.15.0 uses a new neural network architecture with `sgf_metadata_encoder` blocks that v1.14.1 doesn't understand
- Bump chart version to 1.3.0

## Problem
When using the custom human-style model, KataGo crashes with:
```
Error loading or parsing model file: trunk: found unknown block kind: model.sgf_metadata_encoder
```

## Test plan
- [ ] Docker image builds successfully
- [ ] KataGo can load the human-style model
- [ ] Analysis endpoint returns valid responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)