### PR TITLE
fix: add keepalive mechanism to prevent KataGo subprocess exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "katago-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katago-server"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -5,11 +5,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed.
 # KataGo v1.15.0 required for human-style model support
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 
 keywords:
   - katago


### PR DESCRIPTION
## Summary
- Add 30-second keepalive pings to KataGo subprocess to prevent idle timeout exit
- Add process health tracking with AtomicBool flag for better error detection
- Fix "broken pipe" errors when KataGo exits prematurely (~70 seconds after startup)

## Problem
KataGo analysis engine was exiting after ~70 seconds of idle time, causing:
- `KataGo analysis stdout closed (EOF)` logs
- Subsequent analysis requests failing with "Broken pipe (os error 32)" 
- 504 Gateway Timeout errors

## Solution
Implement a keepalive mechanism that sends periodic `query_version` commands every 30 seconds to keep the KataGo process active and responsive.

## Changes
- Add `KEEPALIVE_INTERVAL_SECS` constant (30 seconds)
- Add `process_alive` AtomicBool flag to track process health
- Add `keepalive_loop` function that sends periodic pings
- Skip routing keepalive responses to avoid polluting pending requests
- Check process health before sending queries

## Test plan
- [ ] Deploy to staging with human-style model
- [ ] Verify KataGo stays alive beyond 2 minutes
- [ ] Test analysis endpoint after extended idle period
- [ ] Monitor logs for keepalive ping messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)