### PR TITLE
fix: use correct player color for moves in handicap games

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katago-server"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [dependencies]

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.7.2
+version: 1.7.3
 
 # This is the version number of the application being deployed.
 # KataGo v1.16.4 for CUDA 12 support and human-style model support
-appVersion: "1.7.2"
+appVersion: "1.7.3"
 
 
 keywords:

--- a/src/analysis_engine.rs
+++ b/src/analysis_engine.rs
@@ -548,8 +548,26 @@ impl AnalysisEngine {
 
         // Convert moves to KataGo format: [["b", "D4"], ["w", "Q16"], ...]
         // Note: KataGo requires lowercase b/w (confirmed by Python implementation and testing)
+        // In handicap games (with initial_stones), White plays first
         let mut katago_moves = Vec::new();
-        let mut color = "b";
+        let has_handicap = request
+            .initial_stones
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+        // Use initial_player if provided, otherwise infer from handicap
+        let first_player = request
+            .initial_player
+            .as_ref()
+            .map(|p| p.to_lowercase())
+            .unwrap_or_else(|| {
+                if has_handicap {
+                    "w".to_string() // White plays first in handicap games
+                } else {
+                    "b".to_string() // Black plays first normally
+                }
+            });
+        let mut color = first_player.as_str();
         for mv in &request.moves {
             katago_moves.push(vec![color.to_string(), mv.clone()]);
             color = if color == "b" { "w" } else { "b" };

--- a/src/analysis_engine.rs
+++ b/src/analysis_engine.rs
@@ -555,9 +555,22 @@ impl AnalysisEngine {
             color = if color == "b" { "w" } else { "b" };
         }
 
+        // Convert initial_stones from API format (tuples) to KataGo format (vecs)
+        // API: [("B", "D16"), ("B", "Q4")] -> KataGo: [["B", "D16"], ["B", "Q4"]]
+        let initial_stones: Vec<Vec<String>> = request
+            .initial_stones
+            .as_ref()
+            .map(|stones| {
+                stones
+                    .iter()
+                    .map(|(color, coord)| vec![color.clone(), coord.clone()])
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let query = AnalysisQuery {
             id: request_id.clone(),
-            initial_stones: vec![], // Empty for standard games (could support handicap via API later)
+            initial_stones,
             moves: katago_moves,
             rules: request.rules.clone().unwrap_or_else(|| {
                 // Auto-detect rules from komi


### PR DESCRIPTION
## Summary
- In handicap games, White plays first (after Black's handicap stones are placed)
- The move color assignment was always starting with Black, causing analysis to be from the wrong perspective
- Now detects handicap games (when initial_stones is present) and starts moves with White
- Also supports explicit initial_player parameter

## Impact
This fixes the territory/score/winrate inversion bug in handicap games. Previously, analysis for positions after move 1 in handicap games would have the wrong perspective, showing Black as losing when Black should be winning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)