### PR TITLE
feat: support explicit move colors for handicap games

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "katago-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/charts/katago-server/Chart.yaml
+++ b/charts/katago-server/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.7.3
+version: 1.7.4
 
 # This is the version number of the application being deployed.
-# KataGo v1.16.4 for CUDA 12 support and human-style model support
-appVersion: "1.7.3"
+# Fix: use correct player color for moves in handicap games
+appVersion: "1.7.4"
 
 
 keywords:


### PR DESCRIPTION
## Summary
- Add `MoveInput` enum that accepts both move formats in the analysis API
- Simple: `["D4", "Q16"]` - colors inferred from alternation
- Explicit: `[["W", "D4"], ["B", "Q16"]]` - colors specified directly

## Problem
KataGo ignores `initialPlayer` for positions with 1+ moves, always assuming Black plays first. This causes incorrect perspective for winrate and territory in handicap games where White plays first.

## Solution
Allow clients to send explicit `[color, coordinate]` pairs so KataGo receives the correct move colors, ensuring proper analysis perspective for handicap games.

## Test plan
- [x] Unit tests for both simple and explicit move formats
- [ ] Integration test with handicap game analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)